### PR TITLE
Fix YAML deprecations

### DIFF
--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -1,7 +1,7 @@
 services:
     tavvet_doctrine_prefix.prefix_naming_strategy:
         class: Tavvet\DoctrinePrefixBundle\Doctrine\ORM\Mapping\PrefixNamingStrategy
-        arguments: [%tavvet_doctrine_prefix.table_prefix%, %tavvet_doctrine_prefix.column_prefix%]
+        arguments: ['%tavvet_doctrine_prefix.table_prefix%', '%tavvet_doctrine_prefix.column_prefix%']
         calls:
             - [setContainer, ['@service_container']]
-            - [setStrategy, [%tavvet_doctrine_prefix.naming_strategy%]]
+            - [setStrategy, ['%tavvet_doctrine_prefix.naming_strategy%']]


### PR DESCRIPTION
http://symfony.com/blog/new-in-symfony-3-1-yaml-deprecations#deprecated-starting-scalars-with-characters

In Symfony 3.1, the usage of % at the beginning of an unquoted string is deprecated and it will be removed in Symfony 4.0. 

The solution is simple but a bit tiresome: wrap these strings with single or double quotes.